### PR TITLE
Process and Respond methods in Handlers

### DIFF
--- a/spec/telegram_webhooks/lambda/webhook_spec.rb
+++ b/spec/telegram_webhooks/lambda/webhook_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Lambda::Webhook, :with_lambda do
   context 'with any event' do
     let(:body) { { random: 'param' } }
 
-    it { is_expected.to include(statusCode: 200, body: 'ok') }
+    it { is_expected.to include(statusCode: 200, body: '') }
 
     it 'not raise an error' do
       expect { result }.not_to raise_error

--- a/telegram_webhooks/callback_data.rb
+++ b/telegram_webhooks/callback_data.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
 class CallbackData
+  class << self
+    def parse(data)
+      validate!(data: data)
+
+      result = data.split(PATTERN).drop(1)
+
+      new(base: result[0], source: result[1], source_offset: result[2], quote: result[3], quote_offset: result[4])
+    end
+
+    def validate!(data:)
+      raise "data length exceed #{MAX_LENGTH} chars" if data.length > MAX_LENGTH
+      raise "data doesn't match expected pattern" unless PATTERN.match?(data)
+    end
+  end
+
   attr_accessor :base, :source, :source_offset, :quote, :quote_offset
 
   # Telegram Bot API limitation
   MAX_LENGTH = 64
   PATTERN = /^([\w-]+?):(\w+?)\[(\d+)\]:(\w+?)\[(\d+)\]$/.freeze
-
-  def self.parse(data)
-    validate!(data: data)
-
-    result = data.split(PATTERN).drop(1)
-
-    new(base: result[0], source: result[1], source_offset: result[2], quote: result[3], quote_offset: result[4])
-  end
-
-  def self.validate!(data:)
-    raise "data length exceed #{MAX_LENGTH} chars" if data.length > MAX_LENGTH
-    raise "data doesn't match expected pattern" unless PATTERN.match?(data)
-  end
 
   def initialize(base:, source:, quote:, source_offset: 0, quote_offset: 0)
     @base = base

--- a/telegram_webhooks/event_log.rb
+++ b/telegram_webhooks/event_log.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 class EventLog
-  attr_reader :body, :update_id, :event_type, :time
+  class << self
+    def enqueue(event)
+      puts event
 
-  def self.enqueue(event)
-    puts event
-
-    Lambda.sqs.send_message(
-      queue_url: ENV['LOGS_QUEUE'],
-      message_body: event
-    )
+      Lambda.sqs.send_message(
+        queue_url: ENV['LOGS_QUEUE'],
+        message_body: event
+      )
+    end
   end
+
+  attr_reader :body, :update_id, :event_type, :time
 
   def initialize(log)
     @body = JSON.parse(log['body'])

--- a/telegram_webhooks/exception_handler.rb
+++ b/telegram_webhooks/exception_handler.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ExceptionHandler
+  class << self
+    ENV_TAGS = %w[AWS_LAMBDA_FUNCTION_NAME AWS_LAMBDA_FUNCTION_MEMORY_SIZE AWS_LAMBDA_FUNCTION_VERSION
+                  AWS_REGION].freeze
+
+    attr_reader :extras, :user
+
+    def call(exception, user: nil, **extras)
+      return if skip_exception?(exception)
+
+      @user = user
+      @extras = extras
+
+      if exception.is_a?(RestClient::ExceptionWithResponse)
+        response = exception.response
+        @extras[:response] = { body: response.body, code: response.code, headers: response.headers }
+      end
+
+      capture_exception(exception)
+    end
+
+    private
+
+    def capture_exception(exception)
+      Sentry.with_scope do |scope|
+        scope.set_user(user) if user
+        scope.set_extras(extras)
+        scope.set_tags(tags)
+
+        Sentry.capture_exception(exception)
+      end
+    end
+
+    def tags
+      ENV.slice(*ENV_TAGS)
+    end
+
+    # This method silence down Telegram errors that I shouldn't do anything about
+    def skip_exception?(exception)
+      return false unless exception.is_a?(RestClient::ExceptionWithResponse)
+
+      JSON.parse(exception.response.body)['description'].start_with?('Bad Request: message is not modified')
+    rescue NoMethodError
+      false
+    end
+  end
+end

--- a/telegram_webhooks/handler/inline_query.rb
+++ b/telegram_webhooks/handler/inline_query.rb
@@ -2,12 +2,51 @@
 
 module Handler
   class InlineQuery < Base
-    def handle
-      RestClient.get("https://api.telegram.org/bot#{token}/answerInlineQuery", params: {
-                       inline_query_id: query['id'],
-                       results: build_inline_query_answer(query: query['query']),
-                       cache_time: 60
-                     })
+    def method_name
+      'answerInlineQuery'
+    end
+
+    def params
+      {
+        inline_query_id: query['id'],
+        results: build_inline_query_answer(query: query['query']),
+        cache_time: 0
+      }
+    end
+
+    private
+
+    def build_inline_query_answer(query:)
+      selected = Searcher.call(query: query)
+
+      return [] if selected.empty?
+
+      selected_ids = selected.keys
+      prices = DataSource::CoinGecko.prices(ids: selected_ids, quote: 'USD')
+
+      result = prices.map { |symbol| render_inline_query_item(symbol) }
+
+      result.to_json
+    end
+
+    def render_inline_query_item(symbol)
+      price = Money.from_amount(symbol['current_price'], 'USD').format
+      title = "#{symbol['name']} (#{symbol['symbol'].upcase})"
+      initial_state = CallbackData.new(base: symbol['id'], source: 'coingecko', quote: 'USD')
+
+      {
+        type: :article,
+        id: "#{symbol['id']}:coingecko:USD",
+        title: title,
+        description: "#{price} @ CoinGecko",
+        thumb_url: symbol['image'],
+        thumb_width: 250,
+        thumb_height: 250,
+        input_message_content: {
+          message_text: "#{title} — #{price}"
+        },
+        reply_markup: build_reply_markup(initial_state)
+      }
     end
   end
 end

--- a/telegram_webhooks/lambda/base.rb
+++ b/telegram_webhooks/lambda/base.rb
@@ -2,65 +2,24 @@
 
 module Lambda
   class Base
-    def self.call(event:, context:)
-      handler = new(event: event, context: context)
-      handler.process
+    class << self
+      attr_accessor :trigger
 
-      render
-    rescue StandardError => e
-      capture_exception(e, context: context, event: event, **handler&.sentry_extras)
+      def call(event:, **)
+        handler = new(event: event)
+        handler.process
+      rescue StandardError => e
+        ExceptionHandler.call(e, event: event, **handler&.sentry_extras)
 
-      render
-    end
-
-    def self.render
-      true
-    end
-
-    def self.capture_exception(exception, context:, user: nil, **extras)
-      return if skip_exception?(exception)
-
-      if exception.is_a?(RestClient::ExceptionWithResponse)
-        extras[:response] = response_exception_extras(exception.response)
-      end
-
-      Sentry.with_scope do |scope|
-        scope.set_user(user) if user
-        scope.set_extras(extras)
-
-        tags = exception_tags(context: context)
-        scope.set_tags(tags)
-
-        Sentry.capture_exception(exception)
+        # Log exception to Sentry and swallow it, because I don't want Telegram to resend the event
+        { statusCode: 200, body: '' } if trigger == :api_gateway
       end
     end
 
-    def self.response_exception_extras(response)
-      { body: response.body, code: response.code, headers: response.headers }
-    end
+    attr_reader :event
 
-    def self.exception_tags(context:)
-      {
-        function_name: context.function_name,
-        memory_limit_in_mb: context.memory_limit_in_mb,
-        function_version: context.function_version,
-        aws_region: ENV['AWS_REGION']
-      }
-    end
-
-    def self.skip_exception?(exception)
-      return false unless exception.is_a?(RestClient::ExceptionWithResponse)
-
-      JSON.parse(exception.response.body)['description'].start_with?('Bad Request: message is not modified')
-    rescue NoMethodError
-      false
-    end
-
-    attr_reader :event, :context
-
-    def initialize(event:, context:)
+    def initialize(event:)
       @event = event
-      @context = context
     end
 
     def process


### PR DESCRIPTION
— Now it's possible to call handlers with `#process` method to send telegram command via HTTP request, or with `#respond` to render command immediately for Telegram webhook server consumption
— Move exception capture logic to `ExceptionHandler` class